### PR TITLE
Add docker container for tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.jj
+.git
+.gitignore
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 node_modules
+/.pnpm-store
+
+# Tooling
+.jj
 
 # Output
 .output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:24-alpine
+RUN corepack enable pnpm
+WORKDIR /app
+COPY . /app
+# --force is required for Tailwind installation, that executes a script
+RUN pnpm install --force
+EXPOSE 5173
+CMD ["pnpm", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: help
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+docker-image: ## Build the docker image
+	docker image build --tag breizhcamp .
+
+docker-dev: ## Run the development server inside a container
+    # increasing ulimit is a worakround for "too many open files" error on MacOs
+	ulimit -n 10000 
+	docker container run \
+		--rm \
+		--name breizhcamp-dev\
+		--publish 5173:5173 \
+		--volume $(PWD)/src:/app/src \
+		--volume $(PWD)/static:/app/static \
+		--ulimit nofile=10000:10000 \
+		breizhcamp
+
+docker-build: ## Generate the static website to be deployed using a container, then make it available on http://localhost:4173
+	mkdir build || true
+	rm -fr build/*
+	docker container rm --force breizhcamp-preview || true
+	docker container run \
+		--rm \
+		--name breizhcamp-preview \
+		--publish 4173:4173 \
+		--volume $(PWD)/src:/app/src \
+		--volume $(PWD)/static:/app/static \
+		--volume $(PWD)/build:/app/out \
+		breizhcamp \
+		/app/build-in-docker.sh

--- a/README.md
+++ b/README.md
@@ -2,57 +2,93 @@
 
 Le site Web du BreizCamp est un site statique, généré avec [Svelte](https://svelte.dev/). Svelte est un framework web qui utilise un compilateur pour vous permettre d'écrire des composants concis, en utilisant les API natives des langages que vous connaissez déjà - HTML, CSS et JavaScript !
 
-La majorité des contenus est écrit en Markdown. Il est facile d'y contribuer directement depuis l'interface de GitHub.
+La majorité des contenus est écrite en Markdown. Il est facile d'y contribuer directement depuis l'interface de GitHub.
 
 Ami·es du BreizhCamp, n'hésitez pas à proposer des PR si vous voulez améliorer ce site!
 
-## Développement
+Pour lancer le site sur votre machine, Vous pouvez
+* soit installer Node.js et pnpm,
+* soit utiliser l'image Docker si vous ne souhaitez pas déployer ces outils directement sur votre OS.
 
-### Installer node, npm et pnpm
+## Développement avec Node.js et pnpm
 
-L'installation de NodeJs installe automatiquement npm.
+### Installer node.js et pnpm
 
-**1. windows**
-
-download and install nodeJs: https://nodejs.org/en/download
-
-**1. linux**
+**1. Cloner le projet **
 
 ```sh
-apt install nodejs
-```
+git clone git@github.com:breizhcamp/website-rework.git
+```  
 
-**2. windows et linux**
+**2. Installer Node.js **
 
-```
-npm i -g pnpm
+https://nodejs.org/fr/download
+
+**3. Installer pnpm **
+
+```sh
+corepack enable pnpm
 ```
 
 ### Installer les dépendances
 
 ```sh
-cd path/to/the/project
+cd website-rework
 pnpm i
 ```
 
 ### Démarrer le site en local
 
-```
+```sh
 pnpm dev
 ```
 
-Le site sera accessible sur l'url : http://localhost:5173 et va s'ouvrir automatiquement dans le navigateur configuré par défaut.
+Le site sera accessible sur l'url http://localhost:5173 et va s'ouvrir automatiquement dans le navigateur par défaut.
 
 ### Générer le site statique et le lancer en local
 
-```
+```sh
 pnpm build
 pnpm preview
 ```
 
-Le site sera accessible sur l'url : http://localhost:4173 et va s'ouvrir automatiquement dans le navigateur configuré par défaut.
+Le site sera accessible sur l'url http://localhost:4173 et va s'ouvrir automatiquement dans le navigateur par défaut.
 
-### Contribution
+
+## Développement avec Docker
+
+**Prérequis** : Docker ou un équivalent (Podman, Colima, etc)
+
+**1. Cloner le projet **
+
+```sh
+git clone git@github.com:breizhcamp/website-rework.git
+```
+
+**2. Construire l'image Docker**
+
+```sh
+cd website-rework  
+make docker-image
+```
+
+**3. Lancer le serveur de développement**
+
+```sh
+make docker-dev
+```
+
+Le site sera accessible sur l'URL http://localhost:5173.
+
+### Générer le site statique et le lancer en local
+
+```sh
+make docker-build
+```
+
+Le site généré sera accessible sur l'URL http://localhost:4173.
+
+## Contribution
 
 Les évolutions sont les bienvenues. Merci d'en discuter avec l'équipe du BreizhCamp en direct ou via une issue avant.
 

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Invoking pnpm build on a mounted directory results in a "Resource busy 'build'" error
+# That's why we need to copy the result after it was built
+pnpm build
+rm -fr /app/out/*
+cp -a /app/build/. /app/out
+pnpm preview

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "vite dev --host",
 		"build": "vite build",
-		"preview": "vite preview",
+		"preview": "vite preview --host",
 		"prepare": "svelte-kit sync && husky",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      dev:
+        specifier: ^0.1.3
+        version: 0.1.3
+      pnpm:
+        specifier: ^10.13.1
+        version: 10.13.1
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.5
@@ -863,6 +870,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -973,6 +983,10 @@ packages:
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  dev@0.1.3:
+    resolution: {integrity: sha512-flCHQwAkXk3+1up/wo93Ms9E5Wf9K28ZGA7Oz55nBZ8OTdPPhyvZrwsT+twtySTFHIwv0w9CUNtagZgu1MgzXQ==}
+    hasBin: true
 
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
@@ -1102,6 +1116,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1172,6 +1189,11 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inotify@1.4.6:
+    resolution: {integrity: sha512-WW8/uqIA04O3AePQVe/Ms3ZLR0yGamaz8YOEpaXc4WBAGOPZfzu58wWErEPSUYaPyDrJRIeCn6PEIQgC1ZyQ5w==}
+    engines: {node: '>=0.8'}
+    os: [linux]
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1386,6 +1408,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nan@2.23.0:
+    resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
+
   nano-spawn@1.0.2:
     resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
     engines: {node: '>=20.17'}
@@ -1447,6 +1472,11 @@ packages:
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
+    hasBin: true
+
+  pnpm@10.13.1:
+    resolution: {integrity: sha512-N+vxpcejDV+r4MXfRO6NpMllygxa89urKMOhaBtwolYhjQXIHJwNz3Z+9rhVHrW5YAQrntQwDFkkIzY3fgHPrQ==}
+    engines: {node: '>=18.12'}
     hasBin: true
 
   postcss-load-config@3.1.4:
@@ -2709,6 +2739,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -2795,6 +2829,10 @@ snapshots:
   deepmerge@4.3.1: {}
 
   detect-libc@2.0.4: {}
+
+  dev@0.1.3:
+    dependencies:
+      inotify: 1.4.6
 
   devalue@5.1.1: {}
 
@@ -2970,6 +3008,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3021,6 +3061,11 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inotify@1.4.6:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.23.0
 
   is-extglob@2.1.1: {}
 
@@ -3207,6 +3252,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nan@2.23.0: {}
+
   nano-spawn@1.0.2: {}
 
   nanoid@3.3.11: {}
@@ -3253,6 +3300,8 @@ snapshots:
   picomatch@4.0.2: {}
 
   pidtree@0.6.0: {}
+
+  pnpm@10.13.1: {}
 
   postcss-load-config@3.1.4(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
Cette PR ajoute la possibilité d'utiliser des containers Docker pour éviter d'installer Node.js, les dépendances et l'outillage associé sur l'OS hôte.

**Comment tester ?**

La procédure est décrite dans le README.

